### PR TITLE
Use tempdir for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 /target
 .yit
-foobar
-/ehoo
 /tmp

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .yit
 foobar
 /ehoo
+/tmp

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,21 @@
-use crate::repo;
-
 #[test]
 fn test_flow() {
+    use crate::repo;
+    use std::{fs, env};
+
+    // Reset "tmp" directory:
+    let _ = fs::remove_dir_all("tmp");
+    fs::create_dir("tmp").unwrap();
+    fs::write("tmp/.gitkeep", b"").unwrap();
+
+    // Create initial state:
+    env::set_current_dir("tmp").unwrap();
+    fs::write("foobar", b"test content").unwrap();
+    fs::create_dir("ehoo").unwrap();
+    fs::write("ehoo\\daaa", b"another test").unwrap();
+    fs::create_dir("src").unwrap();
+    fs::write("src\\tree.rs", b"fn rust_code() {}").unwrap();
+
     let repo = repo::Repository::new();
     let _ = repo.clone().init();
     let res = repo.clone().add(String::from("foobar"));


### PR DESCRIPTION
Вместо да се очакват конкретни файлове в локалната директория (и да се създава `.yit` папка, която не се зачиства), по-удобно е да си се направи една временна папка, където да се маже и после да се зачиства.

При повече от един тест, това може да не е достатъчно, понеже тестовете се пускат паралелно by default. Но в случая, това би трябвало да е good enough. В случай на любопитство, тук съм разказал повече за тестване на файлови операции: https://andrewra.dev/2019/03/01/testing-in-rust-temporary-files/