### PR TITLE
Extract tests to separate directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 /target
 .yit
-foobar
-/ehoo
 /tmp

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .yit
 foobar
 /ehoo
+/tmp

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod blob;
+pub mod branch;
+pub mod commit;
+pub mod file;
+pub mod index;
+pub mod repo;
+pub mod tree;
+pub mod merge;
+pub mod commandparser;
+pub mod diff;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,3 @@
-mod blob;
-mod branch;
-mod commit;
-mod file;
-mod index;
-mod repo;
-mod tree;
-mod merge;
-mod commandparser;
-mod diff;
-mod test;
-
 fn main() {
-    commandparser::read_command();
+    yit::commandparser::read_command();
 }
-

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,21 @@
-use crate::repo;
-
 #[test]
 fn test_flow() {
+    use crate::repo;
+    use std::{fs, env};
+
+    // Reset "tmp" directory:
+    let _ = fs::remove_dir_all("tmp");
+    fs::create_dir("tmp").unwrap();
+    fs::write("tmp/.gitkeep", b"").unwrap();
+
+    // Create initial state:
+    env::set_current_dir("tmp").unwrap();
+    fs::write("foobar", b"test content").unwrap();
+    fs::create_dir("ehoo").unwrap();
+    fs::write("ehoo\\daaa", b"another test").unwrap();
+    fs::create_dir("src").unwrap();
+    fs::write("src\\tree.rs", b"fn rust_code() {}").unwrap();
+
     let repo = repo::Repository::new();
     let _ = repo.clone().init();
     let res = repo.clone().add(String::from("foobar"));

--- a/tests/test_flow.rs
+++ b/tests/test_flow.rs
@@ -1,8 +1,8 @@
+use yit::repo;
+use std::{fs, env};
+
 #[test]
 fn test_flow() {
-    use crate::repo;
-    use std::{fs, env};
-
     // Reset "tmp" directory:
     let _ = fs::remove_dir_all("tmp");
     fs::create_dir("tmp").unwrap();


### PR DESCRIPTION
Вместо тестовете да са част от "главния" код, има смисъл да бъдат отделени. Затова се получаваше warning от `test` модула за `use crate::repo` -- кода не се компилира само за тестове, но и във всички контексти, но `crate::repo` се използва само във функция, която съществува при тестване.

Това е сложено отгоре на https://github.com/yzelova/Yit/pull/3